### PR TITLE
Fixed DEMto3D for QGIS 3.14 "pi"

### DIFF
--- a/DEMto3D_Dialog/DEMto3D_dialog.py
+++ b/DEMto3D_Dialog/DEMto3D_dialog.py
@@ -109,10 +109,10 @@ class DEMto3DDialog(QDialog, Ui_DEMto3DDialogBase):
         # region LAYER ACTION
         # fill layer combobox with raster visible layers in mapCanvas
         self.viewLayers = self.canvas.layers()
-        self.ui.mMapLayerComboBox.clear()
+        # self.ui.mMapLayerComboBox.clear()
         self.ui.mMapLayerComboBox.setFilters(QgsMapLayerProxyModel.RasterLayer)
-        self.layer = self.ui.mMapLayerComboBox.currentLayer()
-        self.get_raster_properties()
+        # self.layer = self.ui.mMapLayerComboBox.currentLayer()
+        # self.get_raster_properties()
         self.ui.mMapLayerComboBox.layerChanged.connect(self.get_currlayer)
         # endregion
 


### PR DESCRIPTION
removed mMapLayerComboBox.clear() because the dropdown was not getting populated properly after that. It was causing the layer to be 'None'

I also removed mMapLayerComboBox.currentLayer() in case there are no active layers that are Rasters. 
If there are no rasters, the combo box will just be blank, and that's fine. Better than the plugin crashing.

I've tested on QGIS 3.14 for MacOS.